### PR TITLE
Windows and OS X builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,3 +55,7 @@ if (NOT FIPS_IMPORT)
     fips_finish()
 endif()
 
+if(FIPS_MSVC)
+    set_target_properties(glcpp_library PROPERTIES COMPILE_FLAGS "/wd4005 /wd4090 /wd4291")
+    set_target_properties(glsl_optimizer PROPERTIES COMPILE_FLAGS "/wd4005 /wd4311 /wd4312 /wd4291 /wd4715 /wd4805")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,5 +57,5 @@ endif()
 
 if(FIPS_MSVC)
     set_target_properties(glcpp_library PROPERTIES COMPILE_FLAGS "/wd4005 /wd4090 /wd4291")
-    set_target_properties(glsl_optimizer PROPERTIES COMPILE_FLAGS "/wd4005 /wd4311 /wd4312 /wd4291 /wd4715 /wd4805")
+    set_target_properties(glsl_optimizer PROPERTIES COMPILE_FLAGS "/wd4005 /wd4311 /wd4312 /wd4291 /wd4351 /wd4715 /wd4805")
 endif()


### PR DESCRIPTION
I've been able to compile the static libraries on Windows and OS X.

The 'glslopt' command line app works too, but I needed VS2015 on Windows - VS2013 doesn't compile because of some 'snprintf identifier not found' mess.

Also pulled the latest version from glsl-optimizer.
